### PR TITLE
feat: add eps_average_mode 

### DIFF
--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -797,7 +797,7 @@ class NEGF(object):
         #     ik = update_kmap(self.results_path, kpoint=k)
         for p in properties:
             # log.info(msg="Computing {0} at k = {1}".format(p, k))
-            prop = self.out.setdefault(p, [])
+            prop: list = self.out.setdefault(p, [])
             prop.append(getattr(self, "compute_"+p)(kpoint))
 
 
@@ -820,7 +820,7 @@ class NEGF(object):
 
     def compute_current(self, kpoint):
         self.deviceprop.cal_green_function(e=self.int_grid, kpoint=kpoint, block_tridiagonal=self.block_tridiagonal)
-        return self.devidevicepropce.current
+        return self.deviceprop.current
     
     def compute_lcurrent(self, kpoint):
         return self.deviceprop.lcurrent


### PR DESCRIPTION
This pull request introduces a new feature to the Poisson solver by allowing users to select between harmonic and arithmetic averaging modes for dielectric constants. It also refactors the code to incorporate this functionality while maintaining backward compatibility. Below are the key changes:

### Feature Addition:
* Added a new parameter `eps_average_mode` to the `Interface3D` class initializer, allowing users to specify the averaging mode for dielectric constants. The default mode is set to `'harmonic'`. (`dpnegf/negf/poisson_init.py`, [dpnegf/negf/poisson_init.pyL287-R287](diffhunk://#diff-d2f8d0b0728acc26961d4b68a35bff741b087781872484212732358a2a8a9193L287-R287))

### Code Refactoring:
* Introduced an `average_eps` helper function within the `NR_construct_Jac_B` method to compute the average dielectric constant based on the selected mode (`harmonic` or `arithmetic`). This function replaces the previous hardcoded harmonic averaging logic. (`dpnegf/negf/poisson_init.py`, [dpnegf/negf/poisson_init.pyL642-R671](diffhunk://#diff-d2f8d0b0728acc26961d4b68a35bff741b087781872484212732358a2a8a9193L642-R671))
* Updated all flux calculations in the `NR_construct_Jac_B` method to use the new `average_eps` function, ensuring consistency and flexibility in the averaging logic. (`dpnegf/negf/poisson_init.py`, [dpnegf/negf/poisson_init.pyL642-R671](diffhunk://#diff-d2f8d0b0728acc26961d4b68a35bff741b087781872484212732358a2a8a9193L642-R671))

### Minor Cleanup:
* Removed redundant trailing whitespace in the `NR_construct_Jac_B` method for better code readability. (`dpnegf/negf/poisson_init.py`, [dpnegf/negf/poisson_init.pyL713-L714](diffhunk://#diff-d2f8d0b0728acc26961d4b68a35bff741b087781872484212732358a2a8a9193L713-L714))…ectric averaging