### PR TITLE
Refactor: extract the translational equivalence check from get_lead_structure()

### DIFF
--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -956,46 +956,6 @@ class NEGFHamiltonianInit(object):
 
     #     return hd, hu, hl, sd, su, sl
 
-# pytest for the newly introduced staticmethod `calc_principal_layers_disp_vec`
-class NEGFHamiltonianInitTest(unittest.TestCase):
-    def test_calc_principal_layers_disp_vec(self):
-        # the normal case with even number of atoms
-        coords = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 1], [1, 1, 1]])
-        thr = 1e-5
-        Rvec_mean = NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords, thr)
-        self.assertTrue(np.allclose(Rvec_mean, np.array([0, 0, 1]), atol=1e-6))
-
-        # the case with odd number of atoms should raise ValueError
-        coords_odd = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 1]])
-        with self.assertRaises(ValueError):
-            NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords_odd, thr)
-        
-        # the case with translational equivalence error larger than threshold
-        coords_error = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 1], [1, 1, 2]])
-        with self.assertRaises(ValueError):
-            NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords_error, thr)
-        
-        # the case with translational equivalence error smaller than threshold
-        coords_equiv = np.array([[0, 0, 0], [1, 1, 0], [0, 0, 1], [1, 1, 1 + 1e-6]])
-        Rvec_mean = NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords_equiv, thr)
-        self.assertTrue(np.allclose(Rvec_mean, np.array([0, 0, 1]), atol=1e-6))
-        # however if we lower the threshold, it should raise ValueError
-        with self.assertRaises(ValueError):
-            NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords_equiv, thr=1e-7)
-        
-        # then a function call to ensure the normal stdout
-        for c in [coords, coords_odd, coords_error, coords_equiv]:
-            try:
-                with self.assertLogs(level='DEBUG') as log:
-                    NEGFHamiltonianInit.calc_principal_layers_disp_vec(c, thr)
-            except ValueError as e:
-                print(f"Caught expected ValueError: {e}")
-                for o in log.output:
-                    print(o)
-        
-if __name__ == "__main__":
-    unittest.main()
-
 # class _NEGFHamiltonianInit(object):
 #     '''The Class for Hamiltonian object in negf module. 
     

--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -2,7 +2,6 @@ import os
 import re
 import h5py
 import logging
-import unittest
 from typing import Optional, Union, List
 
 import torch

--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -517,12 +517,13 @@ class NEGFHamiltonianInit(object):
         if any(e >= thr for e in err_symm): # check on each pair of corresponding atoms
             log.info('The translational vector between corresponding atoms in two principal layers of lead '
                      'that exceed the threshold are:')
-            log.info(f'{"atom indexes":<12} {"layer 1 coordinates":<36} {"layer 2 coordinates":<36}'
-                     f' -> {"displacement vector":<36}')
+            log.info(f'{"atom indexes":<12} {"principal layer 1 atom coordinates":>36} {"principal layer 2 atom coordinates":>36}'
+                     f'    {"displacement vector":>36}')
             log.info('-'*(12 + 36 + 36 + 36 + 6))
             for i, (r1, r2, v, e) in enumerate(zip(coords[int(nat/2):], coords[:int(nat/2)], Rvec, err_symm)):
                 if e >= thr:
-                    log.info('(' + ', '.join([f'{x:>10.6f}' for x in r1])+')' + ' ' + \
+                    log.info(f'{i:>5}, {i+int(nat/2):>5}' + ' ' + \
+                             '(' + ', '.join([f'{x:>10.6f}' for x in r1])+')' + ' ' + \
                              '(' + ', '.join([f'{x:>10.6f}' for x in r2])+')' + ' ' + \
                              '->' + ' ' + \
                              '(' + ', '.join([f'{x:>10.6f}' for x in v ])+')')
@@ -981,6 +982,16 @@ class NEGFHamiltonianInitTest(unittest.TestCase):
         # however if we lower the threshold, it should raise ValueError
         with self.assertRaises(ValueError):
             NEGFHamiltonianInit.calc_principal_layers_disp_vec(coords_equiv, thr=1e-7)
+        
+        # then a function call to ensure the normal stdout
+        for c in [coords, coords_odd, coords_error, coords_equiv]:
+            try:
+                with self.assertLogs(level='DEBUG') as log:
+                    NEGFHamiltonianInit.calc_principal_layers_disp_vec(c, thr)
+            except ValueError as e:
+                print(f"Caught expected ValueError: {e}")
+                for o in log.output:
+                    print(o)
         
 if __name__ == "__main__":
     unittest.main()

--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -480,7 +480,7 @@ class NEGFHamiltonianInit(object):
     def calc_principal_layers_disp_vec(coords, thr=1e-6):
         '''
         calculate the displacement vector between two principal layers of lead structure,
-        by substracting the coordinates of the first half atoms from the second half atoms.
+        by subtracting the coordinates of the first half atoms from the second half atoms.
         This function can also be used to check the translational equivalence of the 
         coordinates between two principal layers.
 


### PR DESCRIPTION
I encounter a bug from ase that the cif file may not be correctly parsed, this will result in the assertion failure of translational equivalence check on principal layers. So it is better to print out all atom coordinates and the displacement vectors in this case for quick-debug.

I also find the 1e-6 threshold may be too strict, so I recover it to 1e-5 as before.