### PR TITLE
Refactor test_get_fermi to use pytest fixture for root directory

### DIFF
--- a/dpnegf/tests/test_get_fermi.py
+++ b/dpnegf/tests/test_get_fermi.py
@@ -1,14 +1,18 @@
+import pytest
 from dpnegf.utils.elec_struc_cal import ElecStruCal
 from dptb.nn.build import build_model
-import os
-from pathlib import Path
-
-rootdir = os.path.join(Path(os.path.abspath(__file__)).parent, "data")
 
 
-def test_get_fermi():
-    ckpt = f"{rootdir}/test_get_fermi/nnsk.best.pth"  #  'hopping': {'method': 'poly2exp', 'rs': 5.0, 'w': 0.6},
-    stru_data = f"{rootdir}/test_get_fermi/PRIMCELL.vasp"
+@pytest.fixture(scope='session', autouse=True)
+def root_directory(request):
+    """
+    :return:
+    """
+    return str(request.config.rootdir)
+
+def test_get_fermi(root_directory):
+    ckpt = f"{root_directory}/dpnegf/tests/data/test_get_fermi/nnsk.best.pth"  #  'hopping': {'method': 'poly2exp', 'rs': 5.0, 'w': 0.6},
+    stru_data = f"{root_directory}/dpnegf/tests/data/test_get_fermi/PRIMCELL.vasp"
 
     model = build_model(checkpoint=ckpt)
     nel_atom = {"Au":11}


### PR DESCRIPTION
Update the test to utilize a pytest fixture for the root directory.