### PR TITLE
Improvements to AtomicData_options handling

### DIFF
--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -73,7 +73,6 @@ class NEGFHamiltonianInit(object):
         self.torch_device = torch_device   
         self.model = model
         self.AtomicData_options = AtomicData_options
-        log.info(msg="The AtomicData_options is {}".format(AtomicData_options))
         self.model.eval()
         
         # get bondlist with pbc in all directions for complete chemical environment

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -139,7 +139,7 @@ class NEGF(object):
         else:
             log.warning(msg="AtomicData_options is extracted from input file. " \
                             "This may be not consistent with the model options. " \
-                            "Please be carefule and check the cutoffs.")
+                            "Please be careful and check the cutoffs.")
         formatted = json.dumps(AtomicData_options, indent=4)
         indented = '\n'.join('               ' + line for line in formatted.splitlines())
         log.info("The AtomicData_options is:\n%s", indented)

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -130,6 +130,17 @@ class NEGF(object):
             else:
                 assert self.stru_options[lead_tag]["voltage"] == 0, f"{lead_tag} voltage should be 0 in non-scf calculation"
 
+        if AtomicData_options is None:
+            from dptb.utils.argcheck import get_cutoffs_from_model_options
+            # get the cutoffs from model options
+            r_max, er_max, oer_max  = get_cutoffs_from_model_options(model.model_options)
+            AtomicData_options = {'r_max': r_max, 'er_max': er_max, 'oer_max': oer_max}
+        else:
+            log.warning(msg="AtomicData_options is extracted from input file. " \
+                            "This may not be consistent with the model options. " \
+                            "Please be carefule and check the cutoffs.")
+            log.info(msg="The AtomicData_options is {}".format(AtomicData_options))
+
         # computing the hamiltonian
         self.negf_hamiltonian = NEGFHamiltonianInit(model=model,
                                                     AtomicData_options=AtomicData_options, 

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -13,6 +13,7 @@ from dpnegf.utils.constants import Boltzmann, eV2J
 import numpy as np
 from dpnegf.utils.make_kpoints import kmesh_sampling_negf
 import logging
+import json
 from dpnegf.negf.poisson_init import Grid,Interface3D,Dirichlet,Dielectric
 from dpnegf.negf.scf_method import PDIISMixer,DIISMixer,BroydenFirstMixer,BroydenSecondMixer,AndersonMixer
 from typing import Optional, Union
@@ -35,7 +36,6 @@ except ImportError:
 class NEGF(object):
     def __init__(self, 
                 model: torch.nn.Module,
-                AtomicData_options: dict, 
                 structure: Union[AtomicData, ase.Atoms, str],
                 ele_T: float,
                 emin: float, emax: float, espacing: float,
@@ -52,6 +52,7 @@ class NEGF(object):
                 out_current: bool=False,out_current_nscf: bool=False,out_ldos: bool=False,out_lcurrent: bool=False,
                 results_path: Optional[str]=None,
                 torch_device: Union[str, torch.device]=torch.device('cpu'),
+                AtomicData_options: Optional[dict]=None, 
                 **kwargs):
         
         
@@ -137,9 +138,11 @@ class NEGF(object):
             AtomicData_options = {'r_max': r_max, 'er_max': er_max, 'oer_max': oer_max}
         else:
             log.warning(msg="AtomicData_options is extracted from input file. " \
-                            "This may not be consistent with the model options. " \
+                            "This may be not consistent with the model options. " \
                             "Please be carefule and check the cutoffs.")
-            log.info(msg="The AtomicData_options is {}".format(AtomicData_options))
+        formatted = json.dumps(AtomicData_options, indent=4)
+        indented = '\n'.join('               ' + line for line in formatted.splitlines())
+        log.info("The AtomicData_options is:\n%s", indented)
 
         # computing the hamiltonian
         self.negf_hamiltonian = NEGFHamiltonianInit(model=model,

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -141,7 +141,7 @@ class NEGF(object):
                             "This may be not consistent with the model options. " \
                             "Please be careful and check the cutoffs.")
         formatted = json.dumps(AtomicData_options, indent=4)
-        indented = '\n'.join('               ' + line for line in formatted.splitlines())
+        indented = '\n'.join(' ' * 15 + line for line in formatted.splitlines())
         log.info("The AtomicData_options is:\n%s", indented)
 
         # computing the hamiltonian


### PR DESCRIPTION
This pull request makes several modifications to improve the handling of `AtomicData_options` and logging in the `dpnegf` package. Key changes include refactoring the initialization of `AtomicData_options` in the `NEGF` class, adding JSON formatting for better readability in logs, and removing redundant logging statements. Target at issue #15 .

### Improvements to `AtomicData_options` handling:
* [`dpnegf/runner/NEGF.py`](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86R55): Refactored the `AtomicData_options` parameter in the `NEGF` class to be optional. Added logic to automatically derive `AtomicData_options` from the model options if not provided, and included a warning when `AtomicData_options` is extracted from the input file to ensure consistency with model options. [[1]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86R55) [[2]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86R134-R146)

### Logging enhancements:
* [`dpnegf/runner/NEGF.py`](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86R134-R146): Introduced JSON formatting for `AtomicData_options` in logging statements to improve readability.
* [`dpnegf/negf/negf_hamiltonian_init.py`](diffhunk://#diff-79798896c22a9fc0e780b16ba70d354d533ad6ff8e8b61ee2ce29d8b1173973bL76): Removed a redundant logging statement that outputs `AtomicData_options`.

### Minor updates:
* [`dpnegf/runner/NEGF.py`](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86R16): Added `json` import to support JSON formatting in logging.
* [`dpnegf/runner/NEGF.py`](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L38): Removed the `AtomicData_options` parameter from the constructor signature where it was not used.