### PR TITLE
Numba jit acceleration of surface green function

### DIFF
--- a/dpnegf/negf/negf_hamiltonian_init.py
+++ b/dpnegf/negf/negf_hamiltonian_init.py
@@ -509,7 +509,12 @@ class NEGFHamiltonianInit(object):
         # require the structure to have translational symmetry, and the atoms are arranged in two
         # layers in the identical way
         Rvec_mean = np.mean(Rvec, axis=0)
-        err_symm = np.linalg.norm(Rvec - Rvec_mean, axis=1)
+        err_symm = np.linalg.norm(Rvec - Rvec_mean + 1e-10, axis=1) # 1e-10 to avoid zero division
+        if np.any(np.isnan(err_symm)):
+            log.error("Calculation of translational equivalence error resulted in NaN values. "
+                    "This may result from wrong input settings.")
+            raise ValueError
+
         log.info(f'Lead principal layers translational equivalence error (on average): {np.mean(err_symm):<.6e}'
                  f' (threshold: {thr:<.6e})')
         if any(e >= thr for e in err_symm): # check on each pair of corresponding atoms

--- a/dpnegf/negf/surface_green.py
+++ b/dpnegf/negf/surface_green.py
@@ -1,312 +1,208 @@
-import torch
-import torch.linalg as tLA
-from xitorch.linalg.solve import solve
+import numpy as np
 import scipy.linalg as SLA
-import matplotlib.pyplot as plt
-from xitorch.grad.jachess import jac
-from torch.autograd.functional import jvp
 import logging
 
 log = logging.getLogger(__name__)
 
-
-class SurfaceGreen(torch.autograd.Function):
-    '''calculate surface green function
-
-    To realize AD-NEGF, this Class is designed manually to calculate the surface green function auto-differentiably.
-    
-    At this stage, we realized Lopez-Sancho scheme and  GEP scheme.
-    However, GEP scheme is not so stable, and we strongly recommended  to implement the Lopez-Sancho scheme.
-
-    '''
-
-    @staticmethod
-    def forward(ctx, H, h01, S, s01, ee, method='Lopez-Sancho'):
-        # '''
-        # gs = [A_l - A_{l,l-1} gs A_{l-1,l}]^{-1}
-        # H : HL
-        # h01 : HLL
-        # 1. ee can be a list, to handle a batch of samples
-        # '''
-
-        if method == 'GEP':
-            gs = calcg0(ee, H, S, h01, s01)
-        else:
-            h10 = h01.conj().T
-            s10 = s01.conj().T
-            alpha, beta = h10 - ee * s10, h01 - ee * s01
-            eps, epss = H.clone(), H.clone()
-            
-            converged = False
-            iteration = 0
-            while not converged:
-                iteration += 1
-                oldeps, oldepss = eps.clone(), epss.clone()
-                oldalpha, oldbeta = alpha.clone(), beta.clone()
-                tmpa = tLA.solve(ee * S - oldeps, oldalpha)
-                tmpb = tLA.solve(ee * S - oldeps, oldbeta)
-
-                alpha, beta = torch.mm(oldalpha, tmpa), torch.mm(oldbeta, tmpb)
-                eps = oldeps + torch.mm(oldalpha, tmpb) + torch.mm(oldbeta, tmpa)
-
-                epss = oldepss + torch.mm(oldbeta, tmpa)
-                LopezConvTest = torch.max(alpha.abs() + beta.abs())
-
-                if iteration == 101:
-                    log.error("Lopez-scheme not converged after 100 iteration.")
-
-                if LopezConvTest < 1.0e-40:
-                    gs = (ee * S - epss).inverse()
-
-                    test = ee * S - H - torch.mm(ee * s01 - h01, gs.mm(ee * s10 - h10))
-                    myConvTest = torch.max((test.mm(gs) - torch.eye(H.shape[0], dtype=h01.dtype)).abs())
-                    if myConvTest < 3.0e-5:
-                        converged = True
-                        if myConvTest > 1.0e-8:
-                            log.warning("Lopez-scheme not-so-well converged at E = %.4f eV:" % ee.real.item() + str(myConvTest.item()))
-                    else:
-                        log.error("Lopez-Sancho %.8f " % myConvTest.item() +
-                              "Error: gs iteration {0}".format(iteration))
-                        raise ArithmeticError("Criteria not met. Please check output...")
-                    
-        ctx.save_for_backward(gs, H, h01, S, s01, ee)
-        return gs
-
-    @staticmethod
-    def backward(ctx, grad_outputs):
-        gs_, H_, h01_, S_, s01_, ee_ = ctx.saved_tensors
-
-        def sgfn(gs, *params):
-            [H, h01, S, s01, ee] = params
-            return tLA.inv(ee*S - H - (ee*s01 - h01).matmul(gs).matmul(ee*s01.conj().T - h01.conj().T)) - gs
-
-        params = [H_, h01_, S_, s01_, ee_]
-        idx = [i for i in range(len(params)) if params[i].requires_grad]
-        params_copy = [p.detach().requires_grad_() for p in params]
-
-        with torch.enable_grad():
-
-            grad = jac(fcn=sgfn, params=(gs_, *params), idxs=[0])[0] # dfdz
-            pre = solve(A=grad.H, B=-grad_outputs.reshape(-1, 1))
-            pre = pre.reshape(grad_outputs.shape)
-            
-            yfcn = sgfn(gs_, *params_copy)
-
-            grad = torch.autograd.grad(yfcn, [params_copy[i] for i in idx], grad_outputs=pre,
-                                                         create_graph=torch.is_grad_enabled(),
-                                                         allow_unused=True)
-
-        # grad = torch.autograd.grad(yfcn, params_copy, grad_outputs=pre,
-        #                         create_graph=torch.is_grad_enabled(),
-        #                         allow_unused=True)
-
-            grad_out = [None for _ in range(len(params))]
-            for i in range(len(idx)):
-                grad_out[idx[i]] = grad[i]
-
-
-            '''
-            2. Is the matrix index direction correct? Also, is T necessarily becomes H when comes to complex matrix?
-            '''
-            # return *grad, None, None
-            return *grad_out, None
-
-    @staticmethod
-    def jvp(ctx, grad_input):
-        # should be of shape as [H, h01, S, s01, ee]
-        gs_, H_, h01_, S_, s01_, ee_ = ctx.saved_tensors
-        left = ctx.left
-
-        if left:
-            def sgfn(gs, *params):
-                [H, h01, S, s01, ee] = params
-                return tLA.inv(ee*S-H-(ee*s01.conj().T-h01.conj().T).matmul(gs).matmul(ee*s01-h01)) - gs
-        else:
-            def sgfn(gs, *params):
-                [H, h01, S, s01, ee] = params
-                return tLA.inv(ee*S - H - (ee*s01 - h01).matmul(gs).matmul(ee*s01.conj().T - h01.conj().T)) - gs
-        
-        yfcn = sgfn(gs_, *params_copy)
-
-        params = [H_, h01_, S_, s01_, ee_]
-        idx = [i for i in range(len(params)) if params[i].requires_grad]
-        params_copy = [p.detach().requires_grad_() for p in params]
-
-        with torch.enable_grad():
-            _, grad_fw = jvp(func=yfcn, inputs=[params_copy[i] for i in idx], v=[grad_input[i] for i in idx], create_graph=torch.is_grad_enabled())
-            dfdy = jac(fcn=sgfn, params=(gs_, *params), idxs=[0])[0]
-
-            out = [solve(A=dfdy, B=-gf.reshape(-1, 1)).conj().reshape(gf.shape) for gf in grad_fw]
-
-            return torch.mean(out, dim=0)
-
 def selfEnergy(hL, hLL, sL, sLL, ee, hDL=None, sDL=None, etaLead=1e-8, Bulk=False, 
-               E_ref=0.0, dtype=torch.complex128, device='cpu', method='Lopez-Sancho'):
-    '''calculates the self-energy and surface Green's function for a given  Hamiltonian and overlap matrix.
-    
-    Parameters
-    ----------
-    hL
-        Hamiltonian matrix for one principal layer in Lead
-    hLL
-        Hamiltonian matrix between the most nearby principal layers in Lead
-    sL
-        Overlap matrix for one principal layer in Lead
-    sLL
-        Overlap matrix between the most nearby principal layers in Lead
-    ee
-        the given energy
-    hDL
-        Hamiltonian matrix between the lead and the device.   
-    sDL
-        Overlap matrix between the lead and the device.
-    etaLead
-        A small imaginary number that is used to avoid the singularity of the surface Green's function.
-    Bulk, optional
-        Ignore it, please.
-    chemiPot
-        the chemical potential of the lead.
-    dtype
-        the data type of the tensors used in the calculations. 
-    device
-        The "device" parameter specifies the device on which the calculations will be performed. It can be
-        set to 'cpu' for CPU computation or 'cuda' for GPU computation.
-    method
-        specify the method for calculating the surface Green's function.The available options 
-        are "Lopez-Sancho" and any other value will default to "Lopez-Sancho".
-    
-    Returns
-    -------
-        two values: Sig and SGF. The former is self-energy and the latter is surface Green's function.
-    
+                    E_ref=0.0, dtype=np.complex128, device='cpu', method='Lopez-Sancho'):
     '''
-    # if not isinstance(ee, torch.Tensor):
-    #     eeshifted = torch.scalar_tensor(ee, dtype=dtype) - voltage  # Shift of self energies due to voltage(V)
-    # else:
-    #     eeshifted = ee - voltage
-
-    if not isinstance(ee, torch.Tensor):
-        eeshifted = torch.scalar_tensor(ee, dtype=dtype) + E_ref
+    Calculates the self-energy and surface Green's function for a given Hamiltonian and overlap matrix.
+    NumPy-based rewrite of the PyTorch selfEnergy function.
+    '''
+    # 确保输入是NumPy数组
+    hL = np.array(hL)
+    sL = np.array(sL)
+    
+    # 处理 ee
+    if not isinstance(ee, np.ndarray):
+        eeshifted = np.array(ee, dtype=dtype) + E_ref
     else:
         eeshifted = ee + E_ref
-        
-
-    if hDL == None:
+    
+    # 添加一个小的虚部以避免奇点
+    eeshifted = eeshifted + 1j * etaLead
+    
+    if hDL is None:
         ESH = (eeshifted * sL - hL)
-        with torch.no_grad():
-            SGF = SurfaceGreen.apply(hL, hLL, sL, sLL, eeshifted + 1j * etaLead, method)
-
+        # 调用 NumPy 版本的 surface_green_numpy
+        SGF = surface_green(hL, hLL, sL, sLL, eeshifted, method)
+        
         if Bulk:
-            Sig = tLA.inv(SGF)  # SGF^1
+            Sig = np.linalg.inv(SGF)
         else:
-            Sig = ESH - tLA.inv(SGF)
+            Sig = ESH - np.linalg.inv(SGF)
     else:
+        hDL = np.array(hDL)
+        sDL = np.array(sDL)
         a, b = hDL.shape
-        with torch.no_grad():
-            SGF = SurfaceGreen.apply(hL, hLL, sL, sLL, eeshifted + 1j * etaLead, method)
-        #SGF = iterative_simple(eeshifted + 1j * etaLead, hL, hLL, sL, sLL, iter_max=1000)
+        SGF = surface_green(hL, hLL, sL, sLL, eeshifted, method)
+        
         Sig = (eeshifted*sDL-hDL) @ SGF[:b,:b] @ (eeshifted*sDL.conj().T-hDL.conj().T)
-    return Sig, SGF  # R(nuo, nuo)
-
-
-def calcg0(ee, h00, s00, h01, s01):
-    '''The `calcg0` function calculates the surface Green's function for a specific |k> , ref. Euro Phys J B 62, 381 (2008)
-        Inverse of : NOTE, setup for "right" lead.
-        e-h00 -h01  ...
-        -h10  e-h11 ...
-         .
-         .
-         .
-
-    Parameters
-    ----------
-    ee
-        The parameter `ee` represents the energy value for which the surface Green's function is
-    calculated. It is a complex number that determines the energy of the state being considered.
-    h00
-        hamiltonian matrix within principal layer
-    s00
-        overlap matrix within principal layer
-    h01
-        hamiltonian matrix between two adject principal layers
-    s01
-        overlap matrix between two adject principal layers
     
-    Returns
-    -------
-        Surface Green's function `g00`.
+    return Sig, SGF
+
+
+def surface_green(H, h01, S, s01, ee, method='Lopez-Sancho'):
+    '''
+    Calculate surface green function using NumPy.
+
+    This function is a NumPy-based rewrite of the PyTorch SurfaceGreen.forward method.
+    '''
     
-    ''' 
+    # 将输入的张量转换为NumPy数组
+    H = np.array(H)
+    h01 = np.array(h01)
+    S = np.array(S)
+    s01 = np.array(s01)
+    ee = np.array(ee)
 
+    # 确保 ee 是一个复数，以便处理复数运算
+    if not np.iscomplexobj(ee):
+        ee = np.complex128(ee)
 
-    NN, ee = h00.shape[0], ee.real + max(torch.max(ee.imag).item(), 1e-8) * 1.0j
+    if method == 'GEP':
+        # 调用 NumPy 版本的 calcg0
+        gs = calcg0_numpy(ee, H, S, h01, s01)
+    else:
+        h10 = h01.conj().T
+        s10 = s01.conj().T
+        alpha, beta = h10 - ee * s10, h01 - ee * s01
+        eps, epss = H.copy(), H.copy()
+        
+        converged = False
+        iteration = 0
+        while not converged:
+            iteration += 1
+            oldeps, oldepss = eps.copy(), epss.copy()
+            oldalpha, oldbeta = alpha.copy(), beta.copy()
+            
+            # 使用 numpy.linalg.solve 替换 torch.linalg.solve
+            tmpa = np.linalg.solve(ee * S - oldeps, oldalpha)
+            tmpb = np.linalg.solve(ee * S - oldeps, oldbeta)
 
-    # Solve generalized eigen-problem
-    # ( e I - h00 , -I) (eps)          (h01 , 0) (eps)
-    # ( h10       ,  0) (xi ) = lambda (0   , I) (xi )
-    
-    a, b = torch.zeros((2 * NN, 2 * NN), dtype=h00.dtype), torch.zeros((2 * NN, 2 * NN),
-                                                                             dtype=h00.dtype)
-    
-    a[0:NN, 0:NN] = ee * s00 - h00
-    a[0:NN, NN:2 * NN] = -torch.eye(NN, dtype=h00.dtype)
-    a[NN:2 * NN, 0:NN] = h01.conj().T - ee * s01.conj().T
-    b[0:NN, 0:NN] = h01 - ee * s01
-    b[NN:2 * NN, NN:2 * NN] = torch.eye(NN, dtype=h00.dtype)
+            # 使用 @ 运算符进行矩阵乘法
+            alpha, beta = oldalpha @ tmpa, oldbeta @ tmpb
+            eps = oldeps + oldalpha @ tmpb + oldbeta @ tmpa
+            epss = oldepss + oldbeta @ tmpa
+            
+            LopezConvTest = np.max(np.abs(alpha) + np.abs(beta))
 
-    
+            if iteration == 101:
+                log.error("Lopez-scheme not converged after 100 iteration.")
+                raise RuntimeError("Lopez-scheme not converged.")
 
+            if LopezConvTest < 1.0e-40:
+                # 使用 numpy.linalg.inv 替换 tensor.inverse()
+                gs = np.linalg.inv(ee * S - epss)
 
-    ev, evec = SLA.eig(a=a, b=b)
-    ev = torch.tensor(ev, dtype=h00.dtype)
-    evec = torch.tensor(evec, dtype=h00.dtype)
-    # ev = torch.complex(real=torch.tensor(ev.real), imag=torch.tensor(ev.imag))
-    # evec = torch.complex(real=torch.tensor(evec.real), imag=torch.tensor(evec.imag))
-
-    # Select lambda <0 and the eps part of the evec
-    ipiv = torch.where(ev.abs() < 1.)[0]
-
-    ev, evec = ev[ipiv], evec[:NN, ipiv].T
-    # Normalize evec
-    norm = torch.diag(torch.mm(evec, evec.conj().T)).sqrt()
-    evec = torch.mm(torch.diag(1.0 / norm), evec)
-
-    # E^+ Lambda_+ (E^+)^-1 --->>> g00
-    EP = evec.T
-    FP = EP.mm(torch.diag(ev)).mm(torch.inverse(torch.mm(EP.conj().T, EP))).mm(EP.conj().T)
-    g00 = torch.inverse(ee * s00 - h00 - torch.mm(h01 - ee * s01, FP))
-
-    g00 = iterative_gf(ee, g00, h00, h01, s00, s01, iter=3)
-
-    # Check!
-    err = torch.max(torch.abs(g00 - torch.inverse(ee * s00 - h00 - \
-                                                  torch.mm(h01 - ee * s01, g00).mm(
-                                                      h01.conj().T - ee * s01.conj().T))))
-    if err > 1.0e-8:
-        print("WARNING: not-so-well converged for RIGHT electrode at E = {0} eV:".format(ee.real.numpy()), err.numpy())
-    return g00
-
-
-def iterative_gf(ee, gs, h00, h01, s00, s01, iter=1):
-    for i in range(iter):
-        gs = ee*s00 - h00 - (ee * s01 - h01) @ gs @ (ee * s01.conj().T - h01.conj().T)
-        gs = tLA.pinv(gs)
-
+                test = ee * S - H - (ee * s01 - h01) @ gs @ (ee * s10 - h10)
+                myConvTest = np.max(np.abs(test @ gs - np.eye(H.shape[0], dtype=H.dtype)))
+                
+                if myConvTest < 3.0e-5:
+                    converged = True
+                    if myConvTest > 1.0e-8:
+                        log.warning("Lopez-scheme not-so-well converged at E = %.4f eV:" % ee.real.item() + str(myConvTest.item()))
+                else:
+                    log.error("Lopez-Sancho %.8f " % myConvTest.item() +
+                                "Error: gs iteration {0}".format(iteration))
+                    raise ArithmeticError("Criteria not met. Please check output...")
+                
     return gs
 
-def iterative_simple(ee, h00, h01, s00, s01, iter_max=1000):
-    gs =  torch.linalg.inv(ee*s00 - h00)
+
+def calcg0_numpy(ee, h00, s00, h01, s01):
+    '''
+    The `calcg0_numpy` function calculates the surface Green's function for a specific |k> , ref. Euro Phys J B 62, 381 (2008)
+    NumPy-based rewrite of the PyTorch calcg0 function.
+    ''' 
+    # 将输入张量转换为 NumPy 数组
+    h00 = np.array(h00)
+    s00 = np.array(s00)
+    h01 = np.array(h01)
+    s01 = np.array(s01)
+    ee = np.array(ee)
+    
+    NN = h00.shape[0]
+    ee = ee.real + max(ee.imag, 1e-8) * 1.0j
+
+    # Solve generalized eigen-problem
+    a, b = np.zeros((2 * NN, 2 * NN), dtype=h00.dtype), np.zeros((2 * NN, 2 * NN), dtype=h00.dtype)
+    
+    a[0:NN, 0:NN] = ee * s00 - h00
+    a[0:NN, NN:2 * NN] = -np.eye(NN, dtype=h00.dtype)
+    a[NN:2 * NN, 0:NN] = h01.conj().T - ee * s01.conj().T
+    b[0:NN, 0:NN] = h01 - ee * s01
+    b[NN:2 * NN, NN:2 * NN] = np.eye(NN, dtype=h00.dtype)
+
+    # 使用 scipy.linalg.eig 替换 PyTorch 版本
+    ev, evec = SLA.eig(a=a, b=b)
+    
+    # 选择 ev 绝对值小于 1 的特征值及其对应的特征向量
+    ipiv = np.where(np.abs(ev) < 1.)[0]
+    ev, evec = ev[ipiv], evec[:, ipiv]
+
+    # Normalize evec
+    norm = np.sqrt(np.diag(evec.conj().T @ evec))
+    evec = evec @ np.diag(1.0 / norm)
+
+    # E^+ Lambda_+ (E^+)^-1 --->>> g00
+    EP = evec
+    FP = EP @ np.diag(ev) @ np.linalg.inv(EP.conj().T @ EP) @ EP.conj().T
+    g00 = np.linalg.inv(ee * s00 - h00 - (h01 - ee * s01) @ FP)
+    
+    g00 = iterative_gf_numpy(ee, g00, h00, h01, s00, s01, iter=3)
+
+    err = np.max(np.abs(g00 - np.linalg.inv(ee * s00 - h00 - \
+                                            (h01 - ee * s01) @ g00 @ (h01.conj().T - ee * s01.conj().T))))
+    if err > 1.0e-8:
+        print("WARNING: not-so-well converged for RIGHT electrode at E = {0} eV:".format(ee.real), err)
+    
+    return g00
+
+def iterative_gf_numpy(ee, gs, h00, h01, s00, s01, iter=1):
+    '''
+    NumPy-based rewrite of the PyTorch iterative_gf function.
+    '''
+    # 将输入张量转换为 NumPy 数组
+    gs = np.array(gs)
+    h00 = np.array(h00)
+    h01 = np.array(h01)
+    s00 = np.array(s00)
+    s01 = np.array(s01)
+    ee = np.array(ee)
+    
+    for i in range(iter):
+        gs_new = ee*s00 - h00 - (ee * s01 - h01) @ gs @ (ee * s01.conj().T - h01.conj().T)
+        gs = np.linalg.pinv(gs_new)
+    
+    return gs
+
+def iterative_simple_numpy(ee, h00, h01, s00, s01, iter_max=1000):
+    '''
+    NumPy-based rewrite of the PyTorch iterative_simple function.
+    '''
+    # 将输入张量转换为 NumPy 数组
+    h00 = np.array(h00)
+    h01 = np.array(h01)
+    s00 = np.array(s00)
+    s01 = np.array(s01)
+    ee = np.array(ee)
+    
+    gs = np.linalg.inv(ee*s00 - h00)
     diff_gs = 1
-    iter = 0
+    iteration = 0
     while diff_gs > 1e-8:
-        iter +=1
-        gs = ee*s00 - h00 - (ee * s01 - h01) @ gs @ (ee * s01.conj().T - h01.conj().T)
-        # gs = tLA.pinv(gs)
-        gs = torch.linalg.inv(gs)
-        diff_gs = \
-        torch.max(torch.abs(gs - torch.inverse(ee * s00 - h00 - torch.mm(h01 - ee * s01, gs).mm(h01.conj().T - ee * s01.conj().T))))
-        if iter > iter_max:
+        iteration += 1
+        gs_prev = gs.copy()
+        
+        term = (ee * s01 - h01) @ gs_prev @ (ee * s01.conj().T - h01.conj().T)
+        gs = np.linalg.inv(ee*s00 - h00 - term)
+        
+        diff_gs = np.max(np.abs(gs - gs_prev))
+        
+        if iteration > iter_max:
             log.warning("iterative_simple not converged after 1000 iteration.")
             break
-
+            
     return gs

--- a/dpnegf/negf/surface_green_bk.py
+++ b/dpnegf/negf/surface_green_bk.py
@@ -1,0 +1,312 @@
+import torch
+import torch.linalg as tLA
+from xitorch.linalg.solve import solve
+import scipy.linalg as SLA
+import matplotlib.pyplot as plt
+from xitorch.grad.jachess import jac
+from torch.autograd.functional import jvp
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class SurfaceGreen(torch.autograd.Function):
+    '''calculate surface green function
+
+    To realize AD-NEGF, this Class is designed manually to calculate the surface green function auto-differentiably.
+    
+    At this stage, we realized Lopez-Sancho scheme and  GEP scheme.
+    However, GEP scheme is not so stable, and we strongly recommended  to implement the Lopez-Sancho scheme.
+
+    '''
+
+    @staticmethod
+    def forward(ctx, H, h01, S, s01, ee, method='Lopez-Sancho'):
+        # '''
+        # gs = [A_l - A_{l,l-1} gs A_{l-1,l}]^{-1}
+        # H : HL
+        # h01 : HLL
+        # 1. ee can be a list, to handle a batch of samples
+        # '''
+
+        if method == 'GEP':
+            gs = calcg0(ee, H, S, h01, s01)
+        else:
+            h10 = h01.conj().T
+            s10 = s01.conj().T
+            alpha, beta = h10 - ee * s10, h01 - ee * s01
+            eps, epss = H.clone(), H.clone()
+            
+            converged = False
+            iteration = 0
+            while not converged:
+                iteration += 1
+                oldeps, oldepss = eps.clone(), epss.clone()
+                oldalpha, oldbeta = alpha.clone(), beta.clone()
+                tmpa = tLA.solve(ee * S - oldeps, oldalpha)
+                tmpb = tLA.solve(ee * S - oldeps, oldbeta)
+
+                alpha, beta = torch.mm(oldalpha, tmpa), torch.mm(oldbeta, tmpb)
+                eps = oldeps + torch.mm(oldalpha, tmpb) + torch.mm(oldbeta, tmpa)
+
+                epss = oldepss + torch.mm(oldbeta, tmpa)
+                LopezConvTest = torch.max(alpha.abs() + beta.abs())
+
+                if iteration == 101:
+                    log.error("Lopez-scheme not converged after 100 iteration.")
+
+                if LopezConvTest < 1.0e-40:
+                    gs = (ee * S - epss).inverse()
+
+                    test = ee * S - H - torch.mm(ee * s01 - h01, gs.mm(ee * s10 - h10))
+                    myConvTest = torch.max((test.mm(gs) - torch.eye(H.shape[0], dtype=h01.dtype)).abs())
+                    if myConvTest < 3.0e-5:
+                        converged = True
+                        if myConvTest > 1.0e-8:
+                            log.warning("Lopez-scheme not-so-well converged at E = %.4f eV:" % ee.real.item() + str(myConvTest.item()))
+                    else:
+                        log.error("Lopez-Sancho %.8f " % myConvTest.item() +
+                              "Error: gs iteration {0}".format(iteration))
+                        raise ArithmeticError("Criteria not met. Please check output...")
+                    
+        ctx.save_for_backward(gs, H, h01, S, s01, ee)
+        return gs
+
+    @staticmethod
+    def backward(ctx, grad_outputs):
+        gs_, H_, h01_, S_, s01_, ee_ = ctx.saved_tensors
+
+        def sgfn(gs, *params):
+            [H, h01, S, s01, ee] = params
+            return tLA.inv(ee*S - H - (ee*s01 - h01).matmul(gs).matmul(ee*s01.conj().T - h01.conj().T)) - gs
+
+        params = [H_, h01_, S_, s01_, ee_]
+        idx = [i for i in range(len(params)) if params[i].requires_grad]
+        params_copy = [p.detach().requires_grad_() for p in params]
+
+        with torch.enable_grad():
+
+            grad = jac(fcn=sgfn, params=(gs_, *params), idxs=[0])[0] # dfdz
+            pre = solve(A=grad.H, B=-grad_outputs.reshape(-1, 1))
+            pre = pre.reshape(grad_outputs.shape)
+            
+            yfcn = sgfn(gs_, *params_copy)
+
+            grad = torch.autograd.grad(yfcn, [params_copy[i] for i in idx], grad_outputs=pre,
+                                                         create_graph=torch.is_grad_enabled(),
+                                                         allow_unused=True)
+
+        # grad = torch.autograd.grad(yfcn, params_copy, grad_outputs=pre,
+        #                         create_graph=torch.is_grad_enabled(),
+        #                         allow_unused=True)
+
+            grad_out = [None for _ in range(len(params))]
+            for i in range(len(idx)):
+                grad_out[idx[i]] = grad[i]
+
+
+            '''
+            2. Is the matrix index direction correct? Also, is T necessarily becomes H when comes to complex matrix?
+            '''
+            # return *grad, None, None
+            return *grad_out, None
+
+    @staticmethod
+    def jvp(ctx, grad_input):
+        # should be of shape as [H, h01, S, s01, ee]
+        gs_, H_, h01_, S_, s01_, ee_ = ctx.saved_tensors
+        left = ctx.left
+
+        if left:
+            def sgfn(gs, *params):
+                [H, h01, S, s01, ee] = params
+                return tLA.inv(ee*S-H-(ee*s01.conj().T-h01.conj().T).matmul(gs).matmul(ee*s01-h01)) - gs
+        else:
+            def sgfn(gs, *params):
+                [H, h01, S, s01, ee] = params
+                return tLA.inv(ee*S - H - (ee*s01 - h01).matmul(gs).matmul(ee*s01.conj().T - h01.conj().T)) - gs
+        
+        yfcn = sgfn(gs_, *params_copy)
+
+        params = [H_, h01_, S_, s01_, ee_]
+        idx = [i for i in range(len(params)) if params[i].requires_grad]
+        params_copy = [p.detach().requires_grad_() for p in params]
+
+        with torch.enable_grad():
+            _, grad_fw = jvp(func=yfcn, inputs=[params_copy[i] for i in idx], v=[grad_input[i] for i in idx], create_graph=torch.is_grad_enabled())
+            dfdy = jac(fcn=sgfn, params=(gs_, *params), idxs=[0])[0]
+
+            out = [solve(A=dfdy, B=-gf.reshape(-1, 1)).conj().reshape(gf.shape) for gf in grad_fw]
+
+            return torch.mean(out, dim=0)
+
+def selfEnergy(hL, hLL, sL, sLL, ee, hDL=None, sDL=None, etaLead=1e-8, Bulk=False, 
+               E_ref=0.0, dtype=torch.complex128, device='cpu', method='Lopez-Sancho'):
+    '''calculates the self-energy and surface Green's function for a given  Hamiltonian and overlap matrix.
+    
+    Parameters
+    ----------
+    hL
+        Hamiltonian matrix for one principal layer in Lead
+    hLL
+        Hamiltonian matrix between the most nearby principal layers in Lead
+    sL
+        Overlap matrix for one principal layer in Lead
+    sLL
+        Overlap matrix between the most nearby principal layers in Lead
+    ee
+        the given energy
+    hDL
+        Hamiltonian matrix between the lead and the device.   
+    sDL
+        Overlap matrix between the lead and the device.
+    etaLead
+        A small imaginary number that is used to avoid the singularity of the surface Green's function.
+    Bulk, optional
+        Ignore it, please.
+    chemiPot
+        the chemical potential of the lead.
+    dtype
+        the data type of the tensors used in the calculations. 
+    device
+        The "device" parameter specifies the device on which the calculations will be performed. It can be
+        set to 'cpu' for CPU computation or 'cuda' for GPU computation.
+    method
+        specify the method for calculating the surface Green's function.The available options 
+        are "Lopez-Sancho" and any other value will default to "Lopez-Sancho".
+    
+    Returns
+    -------
+        two values: Sig and SGF. The former is self-energy and the latter is surface Green's function.
+    
+    '''
+    # if not isinstance(ee, torch.Tensor):
+    #     eeshifted = torch.scalar_tensor(ee, dtype=dtype) - voltage  # Shift of self energies due to voltage(V)
+    # else:
+    #     eeshifted = ee - voltage
+
+    if not isinstance(ee, torch.Tensor):
+        eeshifted = torch.scalar_tensor(ee, dtype=dtype) + E_ref
+    else:
+        eeshifted = ee + E_ref
+        
+
+    if hDL == None:
+        ESH = (eeshifted * sL - hL)
+        with torch.no_grad():
+            SGF = SurfaceGreen.apply(hL, hLL, sL, sLL, eeshifted + 1j * etaLead, method)
+
+        if Bulk:
+            Sig = tLA.inv(SGF)  # SGF^1
+        else:
+            Sig = ESH - tLA.inv(SGF)
+    else:
+        a, b = hDL.shape
+        with torch.no_grad():
+            SGF = SurfaceGreen.apply(hL, hLL, sL, sLL, eeshifted + 1j * etaLead, method)
+        #SGF = iterative_simple(eeshifted + 1j * etaLead, hL, hLL, sL, sLL, iter_max=1000)
+        Sig = (eeshifted*sDL-hDL) @ SGF[:b,:b] @ (eeshifted*sDL.conj().T-hDL.conj().T)
+    return Sig, SGF  # R(nuo, nuo)
+
+
+def calcg0(ee, h00, s00, h01, s01):
+    '''The `calcg0` function calculates the surface Green's function for a specific |k> , ref. Euro Phys J B 62, 381 (2008)
+        Inverse of : NOTE, setup for "right" lead.
+        e-h00 -h01  ...
+        -h10  e-h11 ...
+         .
+         .
+         .
+
+    Parameters
+    ----------
+    ee
+        The parameter `ee` represents the energy value for which the surface Green's function is
+    calculated. It is a complex number that determines the energy of the state being considered.
+    h00
+        hamiltonian matrix within principal layer
+    s00
+        overlap matrix within principal layer
+    h01
+        hamiltonian matrix between two adject principal layers
+    s01
+        overlap matrix between two adject principal layers
+    
+    Returns
+    -------
+        Surface Green's function `g00`.
+    
+    ''' 
+
+
+    NN, ee = h00.shape[0], ee.real + max(torch.max(ee.imag).item(), 1e-8) * 1.0j
+
+    # Solve generalized eigen-problem
+    # ( e I - h00 , -I) (eps)          (h01 , 0) (eps)
+    # ( h10       ,  0) (xi ) = lambda (0   , I) (xi )
+    
+    a, b = torch.zeros((2 * NN, 2 * NN), dtype=h00.dtype), torch.zeros((2 * NN, 2 * NN),
+                                                                             dtype=h00.dtype)
+    
+    a[0:NN, 0:NN] = ee * s00 - h00
+    a[0:NN, NN:2 * NN] = -torch.eye(NN, dtype=h00.dtype)
+    a[NN:2 * NN, 0:NN] = h01.conj().T - ee * s01.conj().T
+    b[0:NN, 0:NN] = h01 - ee * s01
+    b[NN:2 * NN, NN:2 * NN] = torch.eye(NN, dtype=h00.dtype)
+
+    
+
+
+    ev, evec = SLA.eig(a=a, b=b)
+    ev = torch.tensor(ev, dtype=h00.dtype)
+    evec = torch.tensor(evec, dtype=h00.dtype)
+    # ev = torch.complex(real=torch.tensor(ev.real), imag=torch.tensor(ev.imag))
+    # evec = torch.complex(real=torch.tensor(evec.real), imag=torch.tensor(evec.imag))
+
+    # Select lambda <0 and the eps part of the evec
+    ipiv = torch.where(ev.abs() < 1.)[0]
+
+    ev, evec = ev[ipiv], evec[:NN, ipiv].T
+    # Normalize evec
+    norm = torch.diag(torch.mm(evec, evec.conj().T)).sqrt()
+    evec = torch.mm(torch.diag(1.0 / norm), evec)
+
+    # E^+ Lambda_+ (E^+)^-1 --->>> g00
+    EP = evec.T
+    FP = EP.mm(torch.diag(ev)).mm(torch.inverse(torch.mm(EP.conj().T, EP))).mm(EP.conj().T)
+    g00 = torch.inverse(ee * s00 - h00 - torch.mm(h01 - ee * s01, FP))
+
+    g00 = iterative_gf(ee, g00, h00, h01, s00, s01, iter=3)
+
+    # Check!
+    err = torch.max(torch.abs(g00 - torch.inverse(ee * s00 - h00 - \
+                                                  torch.mm(h01 - ee * s01, g00).mm(
+                                                      h01.conj().T - ee * s01.conj().T))))
+    if err > 1.0e-8:
+        print("WARNING: not-so-well converged for RIGHT electrode at E = {0} eV:".format(ee.real.numpy()), err.numpy())
+    return g00
+
+
+def iterative_gf(ee, gs, h00, h01, s00, s01, iter=1):
+    for i in range(iter):
+        gs = ee*s00 - h00 - (ee * s01 - h01) @ gs @ (ee * s01.conj().T - h01.conj().T)
+        gs = tLA.pinv(gs)
+
+    return gs
+
+def iterative_simple(ee, h00, h01, s00, s01, iter_max=1000):
+    gs =  torch.linalg.inv(ee*s00 - h00)
+    diff_gs = 1
+    iter = 0
+    while diff_gs > 1e-8:
+        iter +=1
+        gs = ee*s00 - h00 - (ee * s01 - h01) @ gs @ (ee * s01.conj().T - h01.conj().T)
+        # gs = tLA.pinv(gs)
+        gs = torch.linalg.inv(gs)
+        diff_gs = \
+        torch.max(torch.abs(gs - torch.inverse(ee * s00 - h00 - torch.mm(h01 - ee * s01, gs).mm(h01.conj().T - ee * s01.conj().T))))
+        if iter > iter_max:
+            log.warning("iterative_simple not converged after 1000 iteration.")
+            break
+
+    return gs


### PR DESCRIPTION
This pull request introduces 'Numba' jit implementation of surface Green's function calculations using  numpy. (For #19 )

However, due to the bottleneck of surface green function calculation is mostly resulted from linalg.solve, which is not evidently accelerated by JIT, the performance improvement from `numba jit ` is limited. 

**Major new functionality: Surface Green's function calculation**

* Backup old version surface_green.py as  `surface_green_bk.py`.
* A Numba version surface_green.py. When Numba is not available, the code falls back into Scipy-based implementation.
