### PR TITLE
Optimization of Self Energy Parser

### DIFF
--- a/dpnegf/entrypoints/run.py
+++ b/dpnegf/entrypoints/run.py
@@ -22,8 +22,8 @@ def run(
         init_model: str,
         structure: str,
         output: str,
-        log_level: int,
         log_path: Optional[str],
+        log_level: int = 20,
         **kwargs
         ):
 

--- a/dpnegf/negf/lead_property.py
+++ b/dpnegf/negf/lead_property.py
@@ -385,7 +385,6 @@ def compute_all_self_energy(eta, lead_L, lead_R, kpoints_grid, energy_grid, n_jo
     save_path_R = os.path.join(lead_R.results_path, "self_energy", "self_energy_leadR.h5")
     
     total_tasks = [(k, e) for k in kpoints_grid for e in energy_grid]
-    print("Total tasks to compute:", len(total_tasks))
     if len(total_tasks) <= batch_size:
         results = Parallel(n_jobs=n_jobs, backend="loky")(
             delayed(self_energy_worker)(k, e, eta, lead_L, lead_R)
@@ -400,7 +399,6 @@ def compute_all_self_energy(eta, lead_L, lead_R, kpoints_grid, energy_grid, n_jo
     else:
         for i in range(0, len(total_tasks), batch_size):
             batch = total_tasks[i:i+batch_size]
-            print("batch idx:", i , "Batch:", batch)
             results = Parallel(n_jobs=n_jobs, backend="loky")(
                 delayed(self_energy_worker)(k, e, eta, lead_L, lead_R)
                 for k, e in batch
@@ -429,7 +427,6 @@ def write_to_hdf5(h5_path, results):
                 log.warning(f"Dataset {dset_name} already exists in group {group_name}. Passing it.")
                 continue 
             grp.create_dataset(dset_name, data=se.cpu().numpy(), compression="gzip")
-            print(f"Written self-energy for kpoint {k} and energy {e} to {h5_path}.")
         f.flush()
 
 

--- a/dpnegf/negf/lead_property.py
+++ b/dpnegf/negf/lead_property.py
@@ -421,8 +421,8 @@ def self_energy_worker(k, e, eta, lead_L, lead_R):
 
 def write_to_hdf5(h5_path, k, e, se):
     with h5py.File(h5_path, "a") as f:
-        group_name = f"k_{k[0]}_{k[1]}_{k[2]}"
-        dset_name = f"E_{e:.8f}"
+        group_name = f"E_{e:.8f}"
+        dset_name = f"k_{k[0]}_{k[1]}_{k[2]}"
         grp = f.require_group(group_name)
         if dset_name in grp:
             log.warning(f"Dataset {dset_name} already exists in group {group_name}. Passing it.")
@@ -431,14 +431,14 @@ def write_to_hdf5(h5_path, k, e, se):
 
 
 
-def read_from_hdf5(h5_path, kpoint, energy):
+def read_from_hdf5(h5_path, k, e):
     with h5py.File(h5_path, "r") as f:
-        group_name = f"k_{kpoint[0]}_{kpoint[1]}_{kpoint[2]}"
-        dset_name = f"E_{energy:.8f}"
+        group_name = f"E_{e:.8f}"
+        dset_name = f"k_{k[0]}_{k[1]}_{k[2]}"
         if group_name in f and dset_name in f[group_name]:
             return f[group_name][dset_name][:]
         else:
-            raise KeyError(f"Data for kpoint {kpoint} and energy {energy} not found.")
+            raise KeyError(f"Data for kpoint {k} and energy {e} not found.")
 
 
 

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -409,7 +409,7 @@ class NEGF(object):
             # profiler.stop()
             # output_path = os.path.join(self.results_path, "profile_report.html")
             # with open(output_path, 'w') as report_file:
-            #     report_file.write(profiler.output_html())
+                # report_file.write(profiler.output_html())
 
     def poisson_negf_scf(self,interface_poisson,atom_gridpoint_index,err=1e-6,max_iter=1000,
                          mix_method:str='linear', mix_rate:float=0.3, tolerance:float=1e-7,Gaussian_sigma:float=3.0):

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -523,6 +523,7 @@ class NEGF(object):
         if hasattr(self, "uni_grid"): self.out["uni_grid"] = self.uni_grid
 
         # self energy calculation
+        log.info(msg="------Self-energy calculation------")
         selfen_parent_dir = os.path.join(self.results_path,"self_energy")
         if not os.path.exists(selfen_parent_dir): 
             os.makedirs(selfen_parent_dir)
@@ -539,7 +540,9 @@ class NEGF(object):
             # In non-scf case, the self-energy of the leads is calculated for each energy point in the energy grid.
             compute_all_self_energy(self.eta_lead, self.deviceprop.lead_L, self.deviceprop.lead_R,
                                     self.kpoints, self.uni_grid)
-    
+        log.info(msg="-----------------------------------\n")
+
+
         for ik, k in enumerate(self.kpoints):
 
             self.out['k'].append(k)

--- a/dpnegf/runner/NEGF.py
+++ b/dpnegf/runner/NEGF.py
@@ -6,7 +6,7 @@ from dpnegf.negf.negf_hamiltonian_init import NEGFHamiltonianInit
 from dpnegf.utils.elec_struc_cal import ElecStruCal
 from dpnegf.negf.density import Ozaki,Fiori
 from dpnegf.negf.device_property import DeviceProperty
-from dpnegf.negf.lead_property import LeadProperty
+from dpnegf.negf.lead_property import LeadProperty, compute_all_self_energy
 from dpnegf.negf.negf_utils import is_fully_covered
 import ase
 from dpnegf.utils.constants import Boltzmann, eV2J
@@ -20,8 +20,7 @@ from typing import Optional, Union
 from dpnegf.utils.tools import apply_gaussian_filter_3d
 from pyinstrument import Profiler
 import os
-from dpnegf.utils.tools import self_energy_worker
-from joblib import Parallel, delayed
+
 
 log = logging.getLogger(__name__)
 
@@ -410,7 +409,7 @@ class NEGF(object):
             # profiler.stop()
             # output_path = os.path.join(self.results_path, "profile_report.html")
             # with open(output_path, 'w') as report_file:
-                # report_file.write(profiler.output_html())
+            #     report_file.write(profiler.output_html())
 
     def poisson_negf_scf(self,interface_poisson,atom_gridpoint_index,err=1e-6,max_iter=1000,
                          mix_method:str='linear', mix_rate:float=0.3, tolerance:float=1e-7,Gaussian_sigma:float=3.0):
@@ -517,38 +516,13 @@ class NEGF(object):
         #         report_file.write(profiler.output_html())
     
 
-    def compute_all_self_energy(self, kpoints_grid, energy_grid, n_jobs=-1):
-        """
-        Compute the self-energy for all combinations of k-points and energy values in parallel using joblib.
-        Parameters:
-            kpoints_grid (Iterable): An iterable of k-point values to compute self-energy for.
-            energy_grid (Iterable): An iterable of energy values to compute self-energy for.
-            n_jobs (int, optional): The number of parallel jobs to run. Defaults to -1 (use all available cores).
-        Notes:
-            This method uses joblib's Parallel to distribute the computation of self-energy across multiple processes.
-            The worker function `self_energy_worker` must be serializable and defined at the top level.
-        """
-        eta = self.eta_lead
-        lead_L = self.deviceprop.lead_L
-        lead_R = self.deviceprop.lead_R
-        # joblib's Parallel and delayed are used to parallelize the self-energy computation
-        # joblib requires worker function to be top-level or serializable
-        Parallel(n_jobs=n_jobs, backend="loky")(
-            delayed(self_energy_worker)(k, e, eta, lead_L, lead_R)
-            for k in kpoints_grid
-            for e in energy_grid
-        )
-
     def negf_compute(self,scf_require=False,Vbias=None):
         
-    
         assert scf_require is not None, "scf_require should be set to True or False"
-
         self.out['k']=[];self.out['wk']=[]
         if hasattr(self, "uni_grid"): self.out["uni_grid"] = self.uni_grid
 
-
-
+        # self energy calculation
         selfen_parent_dir = os.path.join(self.results_path,"self_energy")
         if not os.path.exists(selfen_parent_dir): 
             os.makedirs(selfen_parent_dir)
@@ -559,10 +533,12 @@ class NEGF(object):
             #     for e in self.density.integrate_range:
             #         self.deviceprop.lead_L.self_energy(kpoint=k, energy=e, eta_lead=self.eta_lead, save=True)
             #         self.deviceprop.lead_R.self_energy(kpoint=k, energy=e, eta_lead=self.eta_lead, save=True)
-            self.compute_all_self_energy(self.kpoints, self.density.integrate_range)
+            compute_all_self_energy(self.eta_lead, self.deviceprop.lead_L, self.deviceprop.lead_R,
+                                    self.kpoints, self.density.integrate_range)
         elif not self.scf:
             # In non-scf case, the self-energy of the leads is calculated for each energy point in the energy grid.
-            self.compute_all_self_energy(self.kpoints, self.uni_grid)
+            compute_all_self_energy(self.eta_lead, self.deviceprop.lead_L, self.deviceprop.lead_R,
+                                    self.kpoints, self.uni_grid)
     
         for ik, k in enumerate(self.kpoints):
 

--- a/dpnegf/tests/data/test_negf/test_negf_run/negf_chain_new.json
+++ b/dpnegf/tests/data/test_negf/test_negf_run/negf_chain_new.json
@@ -36,8 +36,8 @@
         },
         "sgf_solver": "Sancho-Rubio",
         "espacing": 0.01,
-        "emin": -2,
-        "emax": 2,
+        "emin": -0.2,
+        "emax": 0.2,
         "e_fermi": -13.638587951660156,
         "density_options": {
             "method": "Ozaki",

--- a/dpnegf/utils/tools.py
+++ b/dpnegf/utils/tools.py
@@ -30,6 +30,7 @@ import urllib
 import zipfile
 import sys
 from scipy.ndimage import gaussian_filter
+import h5py
 
 
 log = logging.getLogger(__name__)
@@ -803,7 +804,3 @@ def apply_gaussian_filter_3d(phi_vector, shape, sigma):
     # Flatten back to 1D
     return phi_3d_filtered.ravel()
 
-
-def self_energy_worker(k, e, eta, lead_L, lead_R):
-    lead_L.self_energy(kpoint=k, energy=e, eta_lead=eta, save=True)
-    lead_R.self_energy(kpoint=k, energy=e, eta_lead=eta, save=True)


### PR DESCRIPTION
This pull request introduces significant improvements to the calculation, storage, and parallelization of lead self-energy computations in the NEGF workflow. The main changes include adding support for HDF5-based storage of self-energies, implementing robust parallel computation and merging of results, and cleaning up related code for better maintainability and performance.

**Parallelized and Efficient Self-Energy Calculation and Storage**

* Added support for saving and loading self-energy data in HDF5 format, including helper functions for writing, reading, and merging HDF5 files, and logic for choosing between `.pth` and `.h5` formats in `LeadProperty` (`dpnegf/negf/lead_property.py`) [[1]](diffhunk://#diff-ebdcd6d3355b71b201d178b9cf4ac7965434c07c528e22a5835fe6b9732aad49L101-R112) [[2]](diffhunk://#diff-ebdcd6d3355b71b201d178b9cf4ac7965434c07c528e22a5835fe6b9732aad49L131-R199) [[3]](diffhunk://#diff-ebdcd6d3355b71b201d178b9cf4ac7965434c07c528e22a5835fe6b9732aad49R357-R474).
* Introduced `compute_all_self_energy` and `self_energy_worker` functions for efficient, batch-parallel computation of self-energies across k-point and energy grids, with temporary file handling and merging for large calculations (`dpnegf/negf/lead_property.py`).
* Updated the main NEGF runner to use the new parallelized self-energy calculation workflow and removed the old, less efficient method (`dpnegf/runner/NEGF.py`) [[1]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L9-R9) [[2]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L23-R23) [[3]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L520-R526) [[4]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L562-R544).

**Codebase Modernization and Clean-up**

* Removed obsolete or redundant code, including the previous `self_energy_worker` and `compute_all_self_energy` implementations from utility modules and the NEGF runner (`dpnegf/utils/tools.py`, `dpnegf/runner/NEGF.py`) [[1]](diffhunk://#diff-b9100982589caf9722842a7df9c48b90f72126aea02b1bc39f3ebe58a7d5faa6L806-L809) [[2]](diffhunk://#diff-0321e0ab1ac75290afc7f4bcf49d30b5b2e9887601ac08e93acf61c7a6a80d86L520-R526).

**Other Minor Improvements**

* Set a default value for `log_level` in the main entrypoint (`dpnegf/entrypoints/run.py`).
* Updated test parameters to use a narrower energy range in the test configuration (`dpnegf/tests/data/test_negf/test_negf_run/negf_chain_new.json`).

These changes collectively enable more scalable, robust, and maintainable NEGF calculations, especially for large systems requiring parallel computation and efficient disk I/O.