### PR TITLE
Add docs

### DIFF
--- a/docs/hands_on/index.rst
+++ b/docs/hands_on/index.rst
@@ -3,4 +3,4 @@ A quick Example
 =================================================
 
 .. toctree::
-   tutorial1_base_sk
+   tutorial1_c_chain


### PR DESCRIPTION
This pull request updates the documentation to reference the correct tutorial in the "A quick Example" section. The change ensures that users are directed to `tutorial1_c_chain` instead of the previous `tutorial1_base_sk`.

Documentation update:

* In `docs/hands_on/index.rst`, the tutorial link under "A quick Example" was changed from `tutorial1_base_sk` to `tutorial1_c_chain`.